### PR TITLE
Add `flake.lock`, add other instantNIX packages to `packages`, and format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ result*
 pkgs/*/sources/
 .venv/
 *.orig
-/flake.lock

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,25 +15,26 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
 
-  outputs = {
-    self,
-    nixpkgs,
-  }: let
-    inherit (nixpkgs) lib;
-    systems = lib.platforms.linux;
-    forAllSystems = lib.genAttrs systems;
-    # forAllSystems = f: lib.genAttrs systems (system: f system);
-    # lib.filterAttrs (n: v: lib.isDerivation v);
-    # lib.filterAttrs (n: lib.isDerivation);
-  in {
-    packages = forAllSystems (system: {
-      default =
-        (import ./default.nix {
-          pkgs = nixpkgs.legacyPackages.${system} or (import nixpkgs {inherit system;});
-        })
-        .instantnix;
-    });
+  outputs =
+    { self
+    , nixpkgs
+    }:
+    let
+      inherit (nixpkgs) lib;
+      systems = lib.platforms.linux;
+      forAllSystems = lib.genAttrs systems;
+      # forAllSystems = f: lib.genAttrs systems (system: f system);
+      # lib.filterAttrs (n: v: lib.isDerivation v);
+      # lib.filterAttrs (n: lib.isDerivation);
+    in
+    {
+      packages = forAllSystems (system: {
+        default =
+          (import ./default.nix {
+            pkgs = nixpkgs.legacyPackages.${system} or (import nixpkgs { inherit system; });
+          }).instantnix;
+      });
 
-    nixosModules = (import ./modules).modules;
-  };
+      nixosModules = (import ./modules).modules;
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -28,12 +28,14 @@
       # lib.filterAttrs (n: lib.isDerivation);
     in
     {
-      packages = forAllSystems (system: {
-        default =
+      packages = forAllSystems (system:
+        lib.filterAttrs (n: v: lib.isDerivation v)
           (import ./default.nix {
             pkgs = nixpkgs.legacyPackages.${system} or (import nixpkgs { inherit system; });
-          }).instantnix;
-      });
+          }) // {
+          default = self.packages.${system}.instantnix;
+        }
+      );
 
       nixosModules = (import ./modules).modules;
     };


### PR DESCRIPTION
### Description
This PR:
*   Check `flake.lock` into the Git tree
*   Format `flake.nix` with nixpkgs-format
*   Add other packages to the `packages` flake attribute

Having the `flake.lock` inside the Git tree helps marking the revisions known to work for this project. Home Manager people add it back to their project some years ago. Sorry for my previous comment to ignore it.

Ignoring `flake.lock` also caused error when using this flake as an input of another flake locally. Users were forced to use the `path:` scheme instead of the `git+file` scheme to avoid error. This patch solves these issues.

The `flake.lock` should be updated either automatically (via GitHub Actions or bots that creates PRs) or manually (via manual PR). We don't have to make the decision and implementation right now; we are tracking Nixpkgs 21.11, which is unlikely to change due to EOL.

We only had the `packgaes.default` flake attribute pointing toward the `instantnix` package, the symlink pack of all the other packages. This patch includes all the packages inside `default.nix` into the `packages` attribute, so that users can access them separately instead of having to use the `instantnix` pack.